### PR TITLE
Context propagation

### DIFF
--- a/request.go
+++ b/request.go
@@ -108,6 +108,6 @@ func NewRequest() Request {
 func FromTyphonRequest(req tmsg.Request) Request {
 	return &request{
 		Request: req,
-		ctx:     context.TODO(),
+		ctx:     context.Background(),
 	}
 }

--- a/requesttree/middleware.go
+++ b/requesttree/middleware.go
@@ -20,6 +20,15 @@ func (m requestTreeMiddleware) ProcessClientRequest(req mercury.Request) mercury
 			req.SetHeader(parentIdHeader, parentId)
 		}
 	}
+
+	// Pass through the current service and endpoint as the origin of this request
+	if svc, ok := req.Value("Service").(string); ok {
+		req.SetHeader("Origin-Service", svc)
+	}
+	if ept, ok := req.Value("Endpoint").(string); ok {
+		req.SetHeader("Origin-Endpoint", ept)
+	}
+
 	return req
 }
 
@@ -34,6 +43,15 @@ func (m requestTreeMiddleware) ProcessServerRequest(req mercury.Request) (mercur
 	if v := req.Headers()[parentIdHeader]; v != "" {
 		req.SetContext(context.WithValue(req.Context(), parentIdCtxKey, v))
 	}
+
+	// Set the current service and endpoint into the context
+	req.SetContext(context.WithValue(req.Context(), "Service", req.Service()))
+	req.SetContext(context.WithValue(req.Context(), "Endpoint", req.Endpoint()))
+
+	// Set the originator into the context
+	req.SetContext(context.WithValue(req.Context(), "Origin-Service", req.Headers()["Origin-Service"]))
+	req.SetContext(context.WithValue(req.Context(), "Origin-Endpoint", req.Headers()["Origin-Endpoint"]))
+
 	return req, nil
 }
 

--- a/requesttree/middleware.go
+++ b/requesttree/middleware.go
@@ -22,10 +22,10 @@ func (m requestTreeMiddleware) ProcessClientRequest(req mercury.Request) mercury
 	}
 
 	// Pass through the current service and endpoint as the origin of this request
-	if svc, ok := req.Value("Service").(string); ok {
+	if svc, ok := req.Value("Current-Service").(string); ok {
 		req.SetHeader("Origin-Service", svc)
 	}
-	if ept, ok := req.Value("Endpoint").(string); ok {
+	if ept, ok := req.Value("Current-Endpoint").(string); ok {
 		req.SetHeader("Origin-Endpoint", ept)
 	}
 
@@ -45,8 +45,8 @@ func (m requestTreeMiddleware) ProcessServerRequest(req mercury.Request) (mercur
 	}
 
 	// Set the current service and endpoint into the context
-	req.SetContext(context.WithValue(req.Context(), "Service", req.Service()))
-	req.SetContext(context.WithValue(req.Context(), "Endpoint", req.Endpoint()))
+	req.SetContext(context.WithValue(req.Context(), "Current-Service", req.Service()))
+	req.SetContext(context.WithValue(req.Context(), "Current-Endpoint", req.Endpoint()))
 
 	// Set the originator into the context
 	req.SetContext(context.WithValue(req.Context(), "Origin-Service", req.Headers()["Origin-Service"]))

--- a/requesttree/middleware.go
+++ b/requesttree/middleware.go
@@ -27,12 +27,8 @@ func (m requestTreeMiddleware) ProcessClientRequest(req mercury.Request) mercury
 	}
 
 	// Pass through the current service and endpoint as the origin of this request
-	if svc, ok := req.Value(currentServiceHeader).(string); ok {
-		req.SetHeader(originServiceHeader, svc)
-	}
-	if ept, ok := req.Value(currentEndpointHeader).(string); ok {
-		req.SetHeader(originEndpointHeader, ept)
-	}
+	req.SetHeader(originServiceHeader, CurrentServiceFor(req))
+	req.SetHeader(originEndpointHeader, CurrentEndpointFor(req))
 
 	return req
 }

--- a/requesttree/middleware.go
+++ b/requesttree/middleware.go
@@ -70,3 +70,35 @@ func (m requestTreeMiddleware) ProcessServerResponse(rsp mercury.Response, ctx c
 func Middleware() requestTreeMiddleware {
 	return requestTreeMiddleware{}
 }
+
+// OriginServiceFor returns the originating service for this context
+func OriginServiceFor(ctx context.Context) string {
+	if s, ok := ctx.Value(originServiceHeader).(string); ok {
+		return s
+	}
+	return ""
+}
+
+// OriginEndpointFor returns the originating endpoint for this context
+func OriginEndpointFor(ctx context.Context) string {
+	if e, ok := ctx.Value(originEndpointHeader).(string); ok {
+		return e
+	}
+	return ""
+}
+
+// CurrentServiceFor returns the current service that this context is executing within
+func CurrentServiceFor(ctx context.Context) string {
+	if s, ok := ctx.Value(currentServiceHeader).(string); ok {
+		return s
+	}
+	return ""
+}
+
+// CurrentEndpointFor returns the current endpoint that this context is executing within
+func CurrentEndpointFor(ctx context.Context) string {
+	if e, ok := ctx.Value(currentEndpointHeader).(string); ok {
+		return e
+	}
+	return ""
+}

--- a/requesttree/middleware.go
+++ b/requesttree/middleware.go
@@ -10,6 +10,11 @@ import (
 const (
 	parentIdHeader = "Parent-Request-ID"
 	reqIdCtxKey    = "Request-ID"
+
+	currentServiceHeader  = "Current-Service"
+	currentEndpointHeader = "Current-Endpoint"
+	originServiceHeader   = "Origin-Service"
+	originEndpointHeader  = "Origin-Endpoint"
 )
 
 type requestTreeMiddleware struct{}
@@ -22,11 +27,11 @@ func (m requestTreeMiddleware) ProcessClientRequest(req mercury.Request) mercury
 	}
 
 	// Pass through the current service and endpoint as the origin of this request
-	if svc, ok := req.Value("Current-Service").(string); ok {
-		req.SetHeader("Origin-Service", svc)
+	if svc, ok := req.Value(currentServiceHeader).(string); ok {
+		req.SetHeader(originServiceHeader, svc)
 	}
-	if ept, ok := req.Value("Current-Endpoint").(string); ok {
-		req.SetHeader("Origin-Endpoint", ept)
+	if ept, ok := req.Value(currentEndpointHeader).(string); ok {
+		req.SetHeader(originEndpointHeader, ept)
 	}
 
 	return req
@@ -45,12 +50,12 @@ func (m requestTreeMiddleware) ProcessServerRequest(req mercury.Request) (mercur
 	}
 
 	// Set the current service and endpoint into the context
-	req.SetContext(context.WithValue(req.Context(), "Current-Service", req.Service()))
-	req.SetContext(context.WithValue(req.Context(), "Current-Endpoint", req.Endpoint()))
+	req.SetContext(context.WithValue(req.Context(), currentServiceHeader, req.Service()))
+	req.SetContext(context.WithValue(req.Context(), currentEndpointHeader, req.Endpoint()))
 
 	// Set the originator into the context
-	req.SetContext(context.WithValue(req.Context(), "Origin-Service", req.Headers()["Origin-Service"]))
-	req.SetContext(context.WithValue(req.Context(), "Origin-Endpoint", req.Headers()["Origin-Endpoint"]))
+	req.SetContext(context.WithValue(req.Context(), originServiceHeader, req.Headers()[originServiceHeader]))
+	req.SetContext(context.WithValue(req.Context(), originEndpointHeader, req.Headers()[originEndpointHeader]))
 
 	return req, nil
 }

--- a/requesttree/middleware_test.go
+++ b/requesttree/middleware_test.go
@@ -41,16 +41,12 @@ func (suite *parentRequestIdMiddlewareSuite) SetupTest() {
 			Handler: func(req mercury.Request) (mercury.Response, error) {
 
 				// Assert first call has correct origin
-				originService, _ := req.Context().Value("Origin-Service").(string)
-				suite.Assert().Equal(testOriginServiceName, originService)
-				originEndpoint, _ := req.Context().Value("Origin-Endpoint").(string)
-				suite.Assert().Equal("e2etest", originEndpoint)
+				suite.Assert().Equal(testOriginServiceName, OriginServiceFor(req))
+				suite.Assert().Equal("e2etest", OriginEndpointFor(req))
 
 				// Assert first call has updated to the current service
-				currentService, _ := req.Context().Value("Current-Service").(string)
-				suite.Assert().Equal(testServiceName, currentService)
-				currentEndpoint, _ := req.Context().Value("Current-Endpoint").(string)
-				suite.Assert().Equal("foo", currentEndpoint)
+				suite.Assert().Equal(testServiceName, CurrentServiceFor(req))
+				suite.Assert().Equal("foo", CurrentEndpointFor(req))
 
 				cl := client.NewClient().
 					SetTransport(suite.trans).
@@ -74,16 +70,12 @@ func (suite *parentRequestIdMiddlewareSuite) SetupTest() {
 			Handler: func(req mercury.Request) (mercury.Response, error) {
 
 				// Assert origin headers were set correctly as previous service
-				originService, _ := req.Context().Value("Origin-Service").(string)
-				suite.Assert().Equal(testServiceName, originService)
-				originEndpoint, _ := req.Context().Value("Origin-Endpoint").(string)
-				suite.Assert().Equal("foo", originEndpoint)
+				suite.Assert().Equal(testServiceName, OriginServiceFor(req))
+				suite.Assert().Equal("foo", OriginEndpointFor(req))
 
 				// And that our current service's headers were set
-				currentService, _ := req.Context().Value("Current-Service").(string)
-				suite.Assert().Equal(testServiceName, currentService)
-				currentEndpoint, _ := req.Context().Value("Current-Endpoint").(string)
-				suite.Assert().Equal("foo-2", currentEndpoint)
+				suite.Assert().Equal(testServiceName, CurrentServiceFor(req))
+				suite.Assert().Equal("foo-2", CurrentEndpointFor(req))
 
 				return req.Response(&testproto.DummyResponse{
 					Pong: ParentRequestIdFor(req)}), nil


### PR DESCRIPTION
Pass the name of the current and originating service through the transport using headers, on the client, and reconstruct these when received on the server, so this is passed through the requesttree.

Also changed the initial context to a `context.Background` when constructed from a Typhon request, rather than a context.TODO, as this is where the request starts, rather than being a location where we need a context but haven't been passed one.

Still todo: tests!