### PR TITLE
Clarify middleware interface; remove response Service/Endpoint

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/suite"
-	"golang.org/x/net/context"
 
 	"github.com/mondough/mercury"
 	"github.com/mondough/mercury/marshaling"
@@ -181,12 +180,12 @@ func (m *testMw) ProcessClientRequest(req mercury.Request) mercury.Request {
 	return req
 }
 
-func (m *testMw) ProcessClientResponse(rsp mercury.Response, ctx context.Context) mercury.Response {
+func (m *testMw) ProcessClientResponse(rsp mercury.Response, req mercury.Request) mercury.Response {
 	rsp.SetHeader("X-Boop", "Boop")
 	return rsp
 }
 
-func (m *testMw) ProcessClientError(err *terrors.Error, ctx context.Context) {
+func (m *testMw) ProcessClientError(err *terrors.Error, req mercury.Request) {
 	m.err = err
 }
 

--- a/client/interface.go
+++ b/client/interface.go
@@ -6,7 +6,6 @@ import (
 	"github.com/mondough/mercury"
 	"github.com/mondough/mercury/transport"
 	terrors "github.com/mondough/typhon/errors"
-	"golang.org/x/net/context"
 )
 
 // A Client is a convenient way to make Requests (potentially in parallel) and access their Responses/Errors.
@@ -59,9 +58,9 @@ type ClientMiddleware interface {
 	// returns an error, ProcessClientError is invoked instead of this method for that request.
 	//
 	// Note that response middleware are applied in reverse order.
-	ProcessClientResponse(rsp mercury.Response, ctx context.Context) mercury.Response
+	ProcessClientResponse(rsp mercury.Response, req mercury.Request) mercury.Response
 	// ProcessClientError is called whenever a remote call results in an error (either local or remote).
 	//
 	// Note that error middleware are applied in reverse order.
-	ProcessClientError(err *terrors.Error, ctx context.Context)
+	ProcessClientError(err *terrors.Error, req mercury.Request)
 }

--- a/request.go
+++ b/request.go
@@ -33,8 +33,6 @@ type Request interface {
 func responseFromRequest(req Request, body interface{}) Response {
 	rsp := NewResponse()
 	rsp.SetId(req.Id())
-	rsp.SetService(req.Service())
-	rsp.SetEndpoint(req.Endpoint())
 	if body != nil {
 		rsp.SetBody(body)
 

--- a/requesttree/middleware.go
+++ b/requesttree/middleware.go
@@ -57,8 +57,8 @@ func (m requestTreeMiddleware) ProcessServerRequest(req mercury.Request) (mercur
 	return req, nil
 }
 
-func (m requestTreeMiddleware) ProcessServerResponse(rsp mercury.Response, ctx context.Context) mercury.Response {
-	if v, ok := ctx.Value(parentIdCtxKey).(string); ok && v != "" && rsp != nil {
+func (m requestTreeMiddleware) ProcessServerResponse(rsp mercury.Response, req mercury.Request) mercury.Response {
+	if v, ok := req.Value(parentIdCtxKey).(string); ok && v != "" && rsp != nil {
 		rsp.SetHeader(parentIdHeader, v)
 	}
 	return rsp

--- a/requesttree/middleware.go
+++ b/requesttree/middleware.go
@@ -33,11 +33,12 @@ func (m requestTreeMiddleware) ProcessClientRequest(req mercury.Request) mercury
 	return req
 }
 
-func (m requestTreeMiddleware) ProcessClientResponse(rsp mercury.Response, ctx context.Context) mercury.Response {
+func (m requestTreeMiddleware) ProcessClientResponse(rsp mercury.Response, req mercury.Request) mercury.Response {
 	return rsp
 }
 
-func (m requestTreeMiddleware) ProcessClientError(err *terrors.Error, ctx context.Context) {}
+func (m requestTreeMiddleware) ProcessClientError(err *terrors.Error, req mercury.Request) {
+}
 
 func (m requestTreeMiddleware) ProcessServerRequest(req mercury.Request) (mercury.Request, mercury.Response) {
 	req.SetContext(context.WithValue(req.Context(), reqIdCtxKey, req.Id()))

--- a/server/interface.go
+++ b/server/interface.go
@@ -3,7 +3,6 @@ package server
 import (
 	"github.com/mondough/mercury"
 	"github.com/mondough/mercury/transport"
-	"golang.org/x/net/context"
 )
 
 // A Server provides Endpoint RPC functionality atop a typhon Transport.
@@ -53,5 +52,5 @@ type ServerMiddleware interface {
 	// Nil responses MUST be handled. If an error is to be returned, use `ErrorResponse`.
 	//
 	// Note that response middleware are applied in reverse order.
-	ProcessServerResponse(rsp mercury.Response, ctx context.Context) mercury.Response
+	ProcessServerResponse(rsp mercury.Response, req mercury.Request) mercury.Response
 }

--- a/server/srv.go
+++ b/server/srv.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	log "github.com/cihub/seelog"
-	"golang.org/x/net/context"
 	"gopkg.in/tomb.v2"
 
 	"github.com/mondough/mercury"
@@ -194,13 +193,13 @@ func (s *server) applyRequestMiddleware(req mercury.Request) (mercury.Request, m
 	return req, nil
 }
 
-func (s *server) applyResponseMiddleware(rsp mercury.Response, ctx context.Context) mercury.Response {
+func (s *server) applyResponseMiddleware(rsp mercury.Response, req mercury.Request) mercury.Response {
 	s.middlewareM.RLock()
 	mws := s.middleware
 	s.middlewareM.RUnlock()
 	for i := len(mws) - 1; i >= 0; i-- { // reverse order
 		mw := mws[i]
-		rsp = mw.ProcessServerResponse(rsp, ctx)
+		rsp = mw.ProcessServerResponse(rsp, req)
 	}
 	return rsp
 }

--- a/server/srv_test.go
+++ b/server/srv_test.go
@@ -97,13 +97,11 @@ func (suite *serverSuite) TestRouting() {
 	suite.Assert().NoError(tmsg.ProtoMarshaler().MarshalBody(req))
 
 	rsp, err := suite.trans.Send(req, time.Second)
-	suite.Assert().NoError(err)
-	suite.Assert().NotNil(rsp)
-	suite.Assert().Equal(req.Service(), rsp.Service())
-	suite.Assert().Equal(req.Endpoint(), rsp.Endpoint())
+	suite.Require().NoError(err)
+	suite.Require().NotNil(rsp)
 
 	suite.Assert().NoError(tmsg.ProtoUnmarshaler(new(testproto.DummyResponse)).UnmarshalPayload(rsp))
-	suite.Assert().NotNil(rsp.Body())
+	suite.Require().NotNil(rsp.Body())
 	suite.Assert().IsType(new(testproto.DummyResponse), rsp.Body())
 	response := rsp.Body().(*testproto.DummyResponse)
 	suite.Assert().Equal("routing", response.Pong)


### PR DESCRIPTION
* As per mondough/typhon#49, `Service` and `Endpoint` are no longer present on `Response`s (just `Request`s)
* Clarify client/server middleware interfaces to explicitly pass `Request`s, not `Context`s.