### PR TITLE
Don't set the default transport to a mock transport

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -166,8 +166,7 @@ func (c *client) performCall(call clientCall, middleware []ClientMiddleware, tra
 	} else if rsp_ != nil {
 		rsp := mercury.FromTyphonResponse(rsp_)
 
-		// Servers set header Content-Error: 1 when sending errors. For those requests, unmarshal the error, leaving the
-		// call's response nil
+		// For error responses, unmarshal the error, leaving the call's response nil
 		if rsp.IsError() {
 			errRsp := rsp.Copy()
 			if unmarshalErr := c.unmarshaler(rsp, &tperrors.Error{}).UnmarshalPayload(errRsp); unmarshalErr != nil {

--- a/client/errorset.go
+++ b/client/errorset.go
@@ -177,3 +177,7 @@ func (es ErrorSet) Error() string {
 	}
 	return ""
 }
+
+func (es ErrorSet) String() string {
+	return es.Error()
+}

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -3,7 +3,6 @@ package transport
 import (
 	"sync"
 
-	"github.com/mondough/typhon/mock"
 	ttrans "github.com/mondough/typhon/transport"
 )
 
@@ -13,10 +12,6 @@ var (
 	defaultTransport  Transport
 	defaultTransportM sync.RWMutex
 )
-
-func init() {
-	SetDefaultTransport(mock.NewTransport())
-}
 
 // DefaultTransport returns the global default transport, over which servers and clients should run by default
 func DefaultTransport() Transport {


### PR DESCRIPTION
It should be set explicitly at a higher level