### PR TITLE
Prevent modifying shared errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: go
 
 go:
-  - 1.4.2
-  - 1.4.3
   - 1.5.2
+  - 1.6
 
 services:
   - rabbitmq

--- a/client/client.go
+++ b/client/client.go
@@ -114,13 +114,18 @@ func (c *client) Errors() ErrorSet {
 	errs := ErrorSet(nil)
 	for uid, call := range c.calls {
 		if call.err != nil {
-			err := call.err
+			err := *(call.err) // Modify a copy
+			copyParams := make(map[string]string, len(err.Params))
+			for k, v := range err.Params {
+				copyParams[k] = v
+			}
+			err.Params = copyParams
 			err.Params[errUidField] = uid
 			if call.req != nil {
 				err.Params[errServiceField] = call.req.Service()
 				err.Params[errEndpointField] = call.req.Endpoint()
 			}
-			errs = append(errs, err)
+			errs = append(errs, &err)
 		}
 	}
 	return errs

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -194,8 +194,7 @@ func (suite *clientSuite) TestMiddleware() {
 	mw := &testMw{}
 	client := NewClient().
 		AddMiddleware(mw).
-		Add(
-		Call{
+		Add(Call{
 			Uid:      "call1",
 			Service:  testServiceName,
 			Endpoint: "ping",
@@ -215,8 +214,7 @@ func (suite *clientSuite) TestMiddleware() {
 	suite.Assert().Nil(mw.err)
 	client = NewClient().
 		AddMiddleware(mw).
-		Add(
-		Call{
+		Add(Call{
 			Uid:      "call1",
 			Service:  testServiceName,
 			Endpoint: "error",
@@ -232,7 +230,8 @@ func (suite *clientSuite) TestMiddleware() {
 	err := client.Errors().ForUid("call1")
 	suite.Require().Error(err)
 	// ProcessClientError should have stored the error
-	suite.Assert().Equal(err, mw.err)
+	suite.Assert().Equal(err.Code, mw.err.Code)
+	suite.Assert().Equal(err.Message, mw.err.Message)
 	// ProcessClientRequest should have set X-Foo: Bar (and ping echoes the headers)
 	suite.Assert().Equal("X-Bar", rsp.Headers()["X-Foo"])
 	// ProcessClientResponse should not have run
@@ -291,14 +290,14 @@ func (suite *clientSuite) TestCustomMarshaler() {
 
 	cl := NewClient().
 		Add(Call{
-		Uid:      "foo",
-		Service:  testServiceName,
-		Endpoint: "bulls--t",
-		Body:     map[string]string{},
-		Response: map[string]string{},
-		Headers: map[string]string{
-			marshaling.ContentTypeHeader: "application/bulls--t",
-			marshaling.AcceptHeader:      "application/bulls--t"}}).
+			Uid:      "foo",
+			Service:  testServiceName,
+			Endpoint: "bulls--t",
+			Body:     map[string]string{},
+			Response: map[string]string{},
+			Headers: map[string]string{
+				marshaling.ContentTypeHeader: "application/bulls--t",
+				marshaling.AcceptHeader:      "application/bulls--t"}}).
 		SetTransport(suite.trans).
 		SetTimeout(time.Second)
 

--- a/client/sugar.go
+++ b/client/sugar.go
@@ -9,8 +9,7 @@ import (
 // protobuf
 func Req(ctx context.Context, service, endpoint string, req, res proto.Message) error {
 	return NewClient().
-		Add(
-		Call{
+		Add(Call{
 			Uid:      "1",
 			Service:  service,
 			Endpoint: endpoint,

--- a/requesttree/middleware_test.go
+++ b/requesttree/middleware_test.go
@@ -50,8 +50,7 @@ func (suite *parentRequestIdMiddlewareSuite) SetupTest() {
 				cl := client.NewClient().
 					SetTransport(suite.trans).
 					SetMiddleware([]client.ClientMiddleware{Middleware()}).
-					Add(
-					client.Call{
+					Add(client.Call{
 						Uid:      "call",
 						Service:  testServiceName,
 						Endpoint: "foo-2",

--- a/service/serverclient_test.go
+++ b/service/serverclient_test.go
@@ -82,8 +82,7 @@ func (suite *clientServerSuite) TestE2E() {
 
 	cl := client.NewClient().
 		SetMiddleware(DefaultClientMiddleware()).
-		Add(
-		client.Call{
+		Add(client.Call{
 			Uid:      "call",
 			Service:  testServiceName,
 			Endpoint: "test",
@@ -116,13 +115,13 @@ func (suite *clientServerSuite) TestErrors() {
 	cl := client.NewClient().
 		SetMiddleware(DefaultClientMiddleware()).
 		Add(
-		client.Call{
-			Uid:      "call",
-			Service:  testServiceName,
-			Endpoint: "error",
-			Body:     &testproto.DummyRequest{},
-			Response: &testproto.DummyResponse{},
-		}).
+			client.Call{
+				Uid:      "call",
+				Service:  testServiceName,
+				Endpoint: "error",
+				Body:     &testproto.DummyRequest{},
+				Response: &testproto.DummyResponse{},
+			}).
 		SetTransport(suite.trans).
 		SetTimeout(time.Second).
 		Execute()


### PR DESCRIPTION
Shared objects should not be mutated. This resolves a data race.