### PR TITLE
Fix propagation of UID for errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 
 go:
-  - 1.5.2
-  - 1.6
+  - 1.6.3
+  - 1.7
 
 install:
   - export PATH=${PATH}:${HOME}/gopath/bin

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ install:
   - export PATH=${PATH}:${HOME}/gopath/bin
   - go get -v -t ./...
   - go get -v github.com/golang/lint/golint
-  - go get -v golang.org/x/tools/cmd/vet
 
 before_script:
   - go vet ./...

--- a/client/client.go
+++ b/client/client.go
@@ -120,9 +120,7 @@ func (c *client) Errors() ErrorSet {
 				copyParams[k] = v
 			}
 			err.Params = copyParams
-			if err.Params[errUidField] == "" {
-				err.Params[errUidField] = uid
-			}
+			err.Params[errUidField] = uid
 			if call.req != nil {
 				if err.Params[errServiceField] == "" {
 					err.Params[errServiceField] = call.req.Service()

--- a/client/sugar.go
+++ b/client/sugar.go
@@ -9,7 +9,7 @@ import (
 func Req(ctx context.Context, service, endpoint string, req, res interface{}) error {
 	return NewClient().
 		Add(Call{
-			Uid:      "1",
+			Uid:      "default",
 			Service:  service,
 			Endpoint: endpoint,
 			Body:     req,


### PR DESCRIPTION
Prevent propagating uids overwriting the `uid` of the call which has errored. If we do propagate `uid` on error then it become impossible for the caller to determine which of their calls has failed.

As an example:

- `service.api.foo` calls `service.bar` with a uid of `hello`
- `service.bar` calls `service.baz` with the `client.Req` method in `sugar.go` which uses a `uid=1`by default (now changed to `uid=default`)
- `service.baz` errors, and returns a `bad_request.something_bad` error back to `service.bar`
- `service.bar` has received an error on its call with `uid=1` and returns this up the stack back to `service.api.foo`
- `service.api.foo` receives this error, marshals this into the `ErrorSet`, and as the `Client-Uid` parameter is set in the error updates the `uid` of the error with `1` _not_ `hello` **< bug >**
- `service.api.foo` checking for `Errors().Any()` will return true, but when it tries to look up the error for its call with the `uid` of `hello` it won't find this, as it is indexed as `1`.

This also changes the default `uid` in sugar.go to `"default"` from `"1"` so it's more obvious - i misread this as a slice or numerically indexed map several times while debugging.